### PR TITLE
Adding initial nodeinfo and well-known endpoints

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,11 @@ use statuses::Status;
 
 const PORT: u16 = 4242;
 
+/// Lookup our base url from the environment or default to localhost:4242
+pub fn base_url() -> &'static str {
+    option_env!("BASE_URL").unwrap_or("127.0.0.1:4242")
+}
+
 // TODO: persistent store for the statuses
 pub type State = Arc<Mutex<HashMap<String, Status>>>;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,4 @@
-use axum::{
-    routing::{delete, get, post},
-    Extension, Router, Server,
-};
+use axum::Server;
 use std::{
     collections::HashMap,
     net::SocketAddr,
@@ -12,9 +9,12 @@ use tracing::{error, info, subscriber};
 use tracing_subscriber::EnvFilter;
 
 mod error;
+mod nodeinfo;
+mod routes;
 mod statuses;
 
 pub use error::Error;
+use routes::build_routes;
 use statuses::Status;
 
 const PORT: u16 = 4242;
@@ -47,14 +47,6 @@ async fn main() {
     }));
 
     run_server().await
-}
-
-pub(crate) fn build_routes(state: State) -> Router {
-    Router::new()
-        .route("/api/v1/statuses", post(statuses::create))
-        .route("/api/v1/statuses/:id", get(statuses::get))
-        .route("/api/v1/statuses/:id", delete(statuses::delete))
-        .layer(Extension(state))
 }
 
 async fn run_server() {

--- a/src/nodeinfo.rs
+++ b/src/nodeinfo.rs
@@ -7,13 +7,15 @@ use axum::{extract::Json, http::header, response::IntoResponse, Extension};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-const NODE_INFO_HEADER: [(header::HeaderName, &str); 1] = [(
-    header::CONTENT_TYPE,
-    "application/json; profile=http://nodeinfo.diaspora.software/ns/schema/2.0#,",
-)];
+pub const NODE_INFO_SCHEMA: &str = "http://nodeinfo.diaspora.software/ns/schema/2.0";
 
 pub async fn get(Extension(state): Extension<State>) -> impl IntoResponse {
-    (NODE_INFO_HEADER, Json(NodeInfo::new(&state)))
+    let headers = [(
+        header::CONTENT_TYPE,
+        format!("application/json; profile={NODE_INFO_SCHEMA}#,"),
+    )];
+
+    (headers, Json(NodeInfo::new(&state)))
 }
 
 /// NodeInfo schema version 2.0

--- a/src/nodeinfo.rs
+++ b/src/nodeinfo.rs
@@ -19,7 +19,7 @@ pub async fn get(Extension(state): Extension<State>) -> impl IntoResponse {
 }
 
 /// NodeInfo schema version 2.0
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct NodeInfo {
     version: &'static str,
@@ -47,7 +47,7 @@ impl NodeInfo {
 }
 
 /// Metadata about server software in use.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Software {
     name: &'static str,
     version: &'static str,
@@ -63,7 +63,7 @@ impl Software {
 }
 
 /// Protocols that can be supported on this server.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum Protocol {
     ActivityPub,
@@ -82,14 +82,14 @@ pub enum Protocol {
 //       empty array for both of these. (If we are, then what services do we want to support?)
 
 /// The third party sites this server can connect to via their application API.
-#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Services {
     inbound: Vec<InboundService>,
     outbound: Vec<OutboundService>,
 }
 
 /// The third party sites this server can retrieve messages from for combined display with regular traffic.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum InboundService {
     #[serde(rename = "atom1.0")]
@@ -104,7 +104,7 @@ pub enum InboundService {
     Twitter, // rip
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum OutboundService {
     #[serde(rename = "atom1.0")]
@@ -143,7 +143,7 @@ pub enum OutboundService {
 //       more later once more of the server is implemented.
 
 /// Usage statistics for this server
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UsageStats {
     users: UserStats,
@@ -161,7 +161,7 @@ impl UsageStats {
 }
 
 /// Statistics about the users of this server
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct UserStats {
     total: u32,

--- a/src/nodeinfo.rs
+++ b/src/nodeinfo.rs
@@ -1,0 +1,168 @@
+//! Support for providing nodeinfo on /nodeinfo/2.0
+//!
+//! The schema for the reponse format can be found here:
+//!   http://nodeinfo.diaspora.software/ns/schema/2.0#
+use crate::State;
+use axum::{extract::Json, http::header, response::IntoResponse, Extension};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+const NODE_INFO_HEADER: [(header::HeaderName, &str); 1] = [(
+    header::CONTENT_TYPE,
+    "application/json; profile=http://nodeinfo.diaspora.software/ns/schema/2.0#,",
+)];
+
+pub async fn get(Extension(state): Extension<State>) -> impl IntoResponse {
+    (NODE_INFO_HEADER, Json(NodeInfo::new(&state)))
+}
+
+/// NodeInfo schema version 2.0
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NodeInfo {
+    version: &'static str,
+    software: Software,
+    protocols: Vec<Protocol>,
+    services: Services,
+    open_registrations: bool,
+    usage: UsageStats,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    meta_data: Option<Value>,
+}
+
+impl NodeInfo {
+    pub fn new(state: &State) -> Self {
+        Self {
+            version: "2.0",
+            software: Software::from_env(),
+            protocols: vec![Protocol::ActivityPub],
+            services: Services::default(),
+            open_registrations: false, // TODO: double check what we should return here as a relay
+            usage: UsageStats::new(state),
+            meta_data: None,
+        }
+    }
+}
+
+/// Metadata about server software in use.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Software {
+    name: &'static str,
+    version: &'static str,
+}
+
+impl Software {
+    fn from_env() -> Self {
+        Self {
+            name: "actiserve",
+            version: option_env!("CARGO_PKG_VERSION").unwrap_or("unknown"),
+        }
+    }
+}
+
+/// Protocols that can be supported on this server.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Protocol {
+    ActivityPub,
+    BuddyCloud,
+    Dfrn,
+    Diaspora,
+    LiberTree,
+    Ostatus,
+    Pumpio,
+    Tent,
+    Xmpp,
+    Zot,
+}
+
+// TODO: Does this need to be implemented using the enums below? We're allowed to return an
+//       empty array for both of these. (If we are, then what services do we want to support?)
+
+/// The third party sites this server can connect to via their application API.
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Services {
+    inbound: Vec<InboundService>,
+    outbound: Vec<OutboundService>,
+}
+
+/// The third party sites this server can retrieve messages from for combined display with regular traffic.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum InboundService {
+    #[serde(rename = "atom1.0")]
+    Atom,
+    GnuSocial,
+    Imap,
+    Pnut,
+    Pop3,
+    Pumpio,
+    #[serde(rename = "rss2.0")]
+    Rss,
+    Twitter, // rip
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum OutboundService {
+    #[serde(rename = "atom1.0")]
+    Atom,
+    Blogger,
+    BuddyCloud,
+    Diaspora,
+    DreamWidth,
+    Dripal,
+    Facebook,
+    Friendica,
+    GnuSocial,
+    Google,
+    InsaneJournal,
+    LiberTree,
+    LinkedIn,
+    LiveJournal,
+    MediaGoblin,
+    MySpace,
+    Pinterest,
+    Pnut,
+    Posterous,
+    Pumpio,
+    RedMatrix,
+    #[serde(rename = "rss2.0")]
+    Rss,
+    Smtp,
+    Tent,
+    Tumbler,
+    Twitter, // rip
+    Wordpress,
+    Xmpp,
+}
+
+// NOTE: the only required field for the spec is users but we might want to provide
+//       more later once more of the server is implemented.
+
+/// Usage statistics for this server
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UsageStats {
+    users: UserStats,
+    // local_posts: u32,
+    // local_comments: u32,
+}
+
+impl UsageStats {
+    // TODO: lookup user stats from persitent state / cache
+    fn new(_state: &State) -> Self {
+        Self {
+            users: UserStats { total: 0 },
+        }
+    }
+}
+
+/// Statistics about the users of this server
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UserStats {
+    total: u32,
+    // active_half_year: u32,
+    // active_month: u32,
+}

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -12,9 +12,45 @@ pub(crate) fn build_routes(state: State) -> Router {
     Router::new()
         // .route("/inbox", post(inbox::post))
         // .route("/.well-known/webfinger", get(webfinger::get))
+        .route("/.well-known/host-meta", get(well_known::host_meta))
+        .route("/.well-known/nodeinfo", get(well_known::nodeinfo))
         .route("/nodeinfo/2.0", get(nodeinfo::get))
         .route("/api/v1/statuses", post(statuses::create))
         .route("/api/v1/statuses/:id", get(statuses::get))
         .route("/api/v1/statuses/:id", delete(statuses::delete))
         .layer(Extension(state))
+}
+
+pub mod well_known {
+    use crate::{base_url, nodeinfo::NODE_INFO_SCHEMA};
+    use axum::{extract::Json, http::header, response::IntoResponse};
+    use serde_json::json;
+
+    pub async fn nodeinfo() -> impl IntoResponse {
+        let headers = [(header::CONTENT_TYPE, "application/json+jrd")];
+        let base = base_url();
+        let body = json!({
+            "links": [
+                {
+                    "rel": NODE_INFO_SCHEMA,
+                    "href": format!("{base}/nodeinfo/2.0"),
+                }
+            ]
+        });
+
+        (headers, Json(body))
+    }
+
+    pub async fn host_meta() -> impl IntoResponse {
+        let headers = [(header::CONTENT_TYPE, "application/xrd+xml")];
+        let base = base_url();
+        let body = format!(
+            r#"<?xml version="1.0"?>
+<XRD xmlns="http://docs.oasis-open.org/ns/xri/xrd-1.0">
+  <Link rel="lrdd" type="application/xrd+xml" template="{base}/.well-known/webfinger?resource={{uri}}"/>
+</XRD>"#
+        );
+
+        (headers, body)
+    }
 }

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -1,0 +1,20 @@
+//! Routes available on this server.
+//!
+//! We are implementing a subset of the activitypub API in order to function as a relay
+use crate::{nodeinfo, statuses, State};
+use axum::{
+    routing::{delete, get, post},
+    Extension, Router,
+};
+
+// TODO: remove statuses endpoints
+pub(crate) fn build_routes(state: State) -> Router {
+    Router::new()
+        // .route("/inbox", post(inbox::post))
+        // .route("/.well-known/webfinger", get(webfinger::get))
+        .route("/nodeinfo/2.0", get(nodeinfo::get))
+        .route("/api/v1/statuses", post(statuses::create))
+        .route("/api/v1/statuses/:id", get(statuses::get))
+        .route("/api/v1/statuses/:id", delete(statuses::delete))
+        .layer(Extension(state))
+}


### PR DESCRIPTION
webfinger needs us to actually have some accounts to lookup first so I'll look into that next. I'm not fully sure what we want / need to set in the response from `nodeinfo` for a few of the fields: the current response is schema compliant and should be fine but we probably want to take a look at providing more accurate details if we can.

```bash
$ curl -s '127.0.0.1:4242/.well-known/host-meta'
<?xml version="1.0"?>
<XRD xmlns="http://docs.oasis-open.org/ns/xri/xrd-1.0">
  <Link rel="lrdd" type="application/xrd+xml" template="127.0.0.1:4242/.well-known/webfinger?resource={uri}"/>
</XRD>%

$ curl -s '127.0.0.1:4242/.well-known/nodeinfo' | jq
{
  "links": [
    {
      "href": "127.0.0.1:4242/nodeinfo/2.0",
      "rel": "http://nodeinfo.diaspora.software/ns/schema/2.0"
    }
  ]
}

$ curl -s '127.0.0.1:4242/nodeinfo/2.0' | jq
{
  "version": "2.0",
  "software": {
    "name": "actiserve",
    "version": "0.1.0"
  },
  "protocols": [
    "activitypub"
  ],
  "services": {
    "inbound": [],
    "outbound": []
  },
  "openRegistrations": false,
  "usage": {
    "users": {
      "total": 0
    }
  }
}
```