### PR TITLE
Adding .well-known endpoints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ axum = "0.5.17"
 chrono = { version = "0.4.19", features = ["serde"] }
 serde = { version = "1.0.143", features = ["derive"] }
 serde_json = "1.0.83"
+simple_test_case = "1.1.0"
 thiserror = "1.0.37"
 tokio = { version = "1.21.2", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1.37"

--- a/src/extractors.rs
+++ b/src/extractors.rs
@@ -1,0 +1,48 @@
+//! Helpers for setting the correct content type when building responses
+use axum::{
+    http::{header, StatusCode},
+    response::{IntoResponse, Response},
+};
+use serde::{Deserialize, Serialize};
+
+/// A helper for returning a JSON jrd document with the correct content header
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Jrd<T>(pub T);
+
+impl<T> IntoResponse for Jrd<T>
+where
+    T: Serialize,
+{
+    fn into_response(self) -> Response {
+        match serde_json::to_string(&self.0) {
+            Ok(s) => ([(header::CONTENT_TYPE, "application/jrd+json")], s).into_response(),
+            Err(err) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                [(header::CONTENT_TYPE, "text/plain;charset=UTF-8")],
+                err.to_string(),
+            )
+                .into_response(),
+        }
+    }
+}
+
+/// A helper for returning an activitypub JSON document with the correct content header
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Activity<T>(pub T);
+
+impl<T> IntoResponse for Activity<T>
+where
+    T: Serialize,
+{
+    fn into_response(self) -> Response {
+        match serde_json::to_string(&self.0) {
+            Ok(s) => ([(header::CONTENT_TYPE, "application/activity+json")], s).into_response(),
+            Err(err) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                [(header::CONTENT_TYPE, "text/plain;charset=UTF-8")],
+                err.to_string(),
+            )
+                .into_response(),
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,27 +1,19 @@
-use axum::{
-    http::{header, StatusCode},
-    response::{IntoResponse, Response},
-    Server,
-};
-use serde::{Deserialize, Serialize};
-use std::{
-    collections::HashMap,
-    net::SocketAddr,
-    panic,
-    sync::{Arc, Mutex},
-};
+use axum::Server;
+use std::{net::SocketAddr, panic, sync::Arc};
 use tracing::{error, info, subscriber};
 use tracing_subscriber::EnvFilter;
 
 mod error;
+mod extractors;
 mod nodeinfo;
 mod routes;
+mod state;
 mod statuses;
 mod well_known;
 
 pub use error::{Error, Result};
 use routes::build_routes;
-use statuses::Status;
+use state::State;
 
 const PORT: u16 = 4242;
 
@@ -29,30 +21,6 @@ const PORT: u16 = 4242;
 pub fn base_url() -> &'static str {
     option_env!("BASE_URL").unwrap_or("127.0.0.1:4242")
 }
-
-/// A helper for returning a JSON jrd document with the correct content header
-#[derive(Debug, Serialize, Deserialize)]
-pub struct Jrd<T>(pub T);
-
-impl<T> IntoResponse for Jrd<T>
-where
-    T: Serialize,
-{
-    fn into_response(self) -> Response {
-        match serde_json::to_string(&self.0) {
-            Ok(s) => ([(header::CONTENT_TYPE, "application/jrd+json")], s).into_response(),
-            Err(err) => (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                [(header::CONTENT_TYPE, "text/plain;charset=UTF-8")],
-                err.to_string(),
-            )
-                .into_response(),
-        }
-    }
-}
-
-// TODO: persistent store for the statuses
-pub type State = Arc<Mutex<HashMap<String, Status>>>;
 
 #[tokio::main]
 async fn main() {
@@ -84,7 +52,7 @@ async fn main() {
 async fn run_server() {
     info!(port = PORT, "starting service");
 
-    let state: State = Arc::new(Mutex::new(HashMap::new()));
+    let state: Arc<State> = Arc::new(State::default());
     let app = build_routes(state);
     let addr = SocketAddr::from(([0, 0, 0, 0], PORT));
 

--- a/src/nodeinfo.rs
+++ b/src/nodeinfo.rs
@@ -6,10 +6,11 @@ use crate::State;
 use axum::{extract::Json, http::header, response::IntoResponse, Extension};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::sync::Arc;
 
 pub const NODE_INFO_SCHEMA: &str = "http://nodeinfo.diaspora.software/ns/schema/2.0";
 
-pub async fn get(Extension(state): Extension<State>) -> impl IntoResponse {
+pub async fn get(Extension(state): Extension<Arc<State>>) -> impl IntoResponse {
     let headers = [(
         header::CONTENT_TYPE,
         format!("application/json; profile={NODE_INFO_SCHEMA}#,"),

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -6,9 +6,10 @@ use axum::{
     routing::{delete, get, post},
     Extension, Router,
 };
+use std::sync::Arc;
 
 // TODO: remove statuses endpoints
-pub(crate) fn build_routes(state: State) -> Router {
+pub(crate) fn build_routes(state: Arc<State>) -> Router {
     Router::new()
         // .route("/inbox", post(inbox::post))
         .route("/.well-known/webfinger", get(well_known::webfinger))

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -1,7 +1,7 @@
 //! Routes available on this server.
 //!
 //! We are implementing a subset of the activitypub API in order to function as a relay
-use crate::{nodeinfo, statuses, State};
+use crate::{nodeinfo, statuses, well_known, State};
 use axum::{
     routing::{delete, get, post},
     Extension, Router,
@@ -11,7 +11,7 @@ use axum::{
 pub(crate) fn build_routes(state: State) -> Router {
     Router::new()
         // .route("/inbox", post(inbox::post))
-        // .route("/.well-known/webfinger", get(webfinger::get))
+        .route("/.well-known/webfinger", get(well_known::webfinger))
         .route("/.well-known/host-meta", get(well_known::host_meta))
         .route("/.well-known/nodeinfo", get(well_known::nodeinfo))
         .route("/nodeinfo/2.0", get(nodeinfo::get))
@@ -19,38 +19,4 @@ pub(crate) fn build_routes(state: State) -> Router {
         .route("/api/v1/statuses/:id", get(statuses::get))
         .route("/api/v1/statuses/:id", delete(statuses::delete))
         .layer(Extension(state))
-}
-
-pub mod well_known {
-    use crate::{base_url, nodeinfo::NODE_INFO_SCHEMA};
-    use axum::{extract::Json, http::header, response::IntoResponse};
-    use serde_json::json;
-
-    pub async fn nodeinfo() -> impl IntoResponse {
-        let headers = [(header::CONTENT_TYPE, "application/json+jrd")];
-        let base = base_url();
-        let body = json!({
-            "links": [
-                {
-                    "rel": NODE_INFO_SCHEMA,
-                    "href": format!("{base}/nodeinfo/2.0"),
-                }
-            ]
-        });
-
-        (headers, Json(body))
-    }
-
-    pub async fn host_meta() -> impl IntoResponse {
-        let headers = [(header::CONTENT_TYPE, "application/xrd+xml")];
-        let base = base_url();
-        let body = format!(
-            r#"<?xml version="1.0"?>
-<XRD xmlns="http://docs.oasis-open.org/ns/xri/xrd-1.0">
-  <Link rel="lrdd" type="application/xrd+xml" template="{base}/.well-known/webfinger?resource={{uri}}"/>
-</XRD>"#
-        );
-
-        (headers, body)
-    }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,0 +1,32 @@
+//! Server shared state
+use crate::statuses::Status;
+use std::{collections::HashMap, sync::Mutex};
+
+#[derive(Debug, Default)]
+pub struct State {
+    pub config: Config,
+    pub db: Db,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct Config {}
+
+// TODO: persistent store for the statuses
+#[derive(Debug, Default)]
+pub struct Db {
+    statuses: Mutex<HashMap<String, Status>>,
+}
+
+impl Db {
+    pub fn insert(&self, id: String, status: Status) {
+        self.statuses.lock().unwrap().insert(id, status);
+    }
+
+    pub fn get(&self, id: &str) -> Option<Status> {
+        self.statuses.lock().unwrap().get(id).cloned()
+    }
+
+    pub fn remove(&self, id: &str) -> Option<Status> {
+        self.statuses.lock().unwrap().remove(id)
+    }
+}

--- a/src/well_known.rs
+++ b/src/well_known.rs
@@ -1,0 +1,128 @@
+use crate::{base_url, nodeinfo::NODE_INFO_SCHEMA, Error, Jrd, Result};
+use axum::{extract::Query, http::header, response::IntoResponse};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+pub async fn host_meta() -> impl IntoResponse {
+    let headers = [(header::CONTENT_TYPE, "application/xrd+xml")];
+    let base = base_url();
+    let body = format!(
+        r#"<?xml version="1.0"?>
+<XRD xmlns="http://docs.oasis-open.org/ns/xri/xrd-1.0">
+  <Link rel="lrdd" type="application/xrd+xml" template="{base}/.well-known/webfinger?resource={{uri}}"/>
+</XRD>"#
+    );
+
+    (headers, body)
+}
+
+pub async fn nodeinfo() -> Jrd<Value> {
+    let base = base_url();
+    let body = json!({
+        "links": [
+            {
+                "rel": NODE_INFO_SCHEMA,
+                "href": format!("{base}/nodeinfo/2.0"),
+            }
+        ]
+    });
+
+    Jrd(body)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Resource {
+    aliases: Vec<String>,
+    links: Vec<Link>,
+    subject: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Link {
+    href: String,
+    rel: String,
+    #[serde(rename = "type")]
+    ty: String,
+}
+
+// TODO: support rel?
+#[derive(Debug, Deserialize)]
+pub struct Params {
+    resource: String,
+}
+
+// https://tools.ietf.org/html/rfc7033
+pub async fn webfinger(Query(Params { resource }): Query<Params>) -> Result<Jrd<Resource>> {
+    let (username, domain) = parse_webfinger_resource(&resource)?;
+    let href = get_href(username, domain);
+    let aliases = get_aliases(username, domain);
+
+    Ok(Jrd(Resource {
+        aliases,
+        subject: resource.clone(),
+        links: vec![
+            Link {
+                href: href.clone(),
+                rel: "https://webfinger.net/rel/profile-page".to_owned(),
+                ty: "application/activity+json".to_owned(),
+            },
+            Link {
+                href,
+                rel: "self".to_owned(),
+                ty: "application/activity+json".to_owned(),
+            },
+        ],
+    }))
+}
+
+// FIXME: actually look up the details
+fn get_href(_username: &str, domain: &str) -> String {
+    format!("https://{domain}/actor")
+}
+
+// FIXME: actually look up the details
+fn get_aliases(_username: &str, _domain: &str) -> Vec<String> {
+    vec![]
+}
+
+// parse a resource param of the form: /.well-known/webfinger?resource=acct:bob@my-example.com
+fn parse_webfinger_resource(resource: &str) -> Result<(&str, &str)> {
+    let uri = match resource.strip_prefix("acct:") {
+        Some(s) => s,
+
+        None => {
+            return Err(Error::MalformedWebfingerResource {
+                resource: resource.to_owned(),
+            })
+        }
+    };
+
+    let parts: Vec<&str> = uri.split('@').collect();
+    if parts.len() != 2 {
+        return Err(Error::MalformedWebfingerUri {
+            uri: uri.to_owned(),
+        });
+    };
+
+    let username = parts[0];
+    let domain = parts[1];
+
+    Ok((username, domain))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use simple_test_case::test_case;
+
+    #[test_case("acct:alice@example.com", Ok(("alice", "example.com")); "valid")]
+    #[test_case("alice@example.com", Err(Error::MalformedWebfingerResource { resource: "alice@example.com".into() }); "missing prefix")]
+    #[test_case("acct:alice@example@com", Err(Error::MalformedWebfingerUri { uri: "alice@example@com".into() }); "multiple at")]
+    #[test_case("acct:alice.example.com", Err(Error::MalformedWebfingerUri { uri: "alice.example.com".into() }); "no at")]
+    #[test]
+    fn parse_webfinger_resource_works(resource: &str, expected: Result<(&str, &str)>) {
+        let res = parse_webfinger_resource(resource);
+
+        assert_eq!(res, expected)
+    }
+}


### PR DESCRIPTION
The parsing logic is tested for the resrource parameter but I've not got enough in place yet to trying things out for real yet. Cribbing heavily from https://git.pleroma.social/pleroma/relay/ as suggested by @dominichamon and I'm part the way through implementing the `inbox` endpoint now (which is what's driving making the server state a little more fleshed out). Rather than push it all as a single "here's a webserver" PR I'm raising the `.well-known` endpoints now :slightly_smiling_face: 